### PR TITLE
feature : 카테고리 별 전체 글 목록 불러오기 Api 추가

### DIFF
--- a/src/main/java/Gdsc/web/controller/api/PostApiController.java
+++ b/src/main/java/Gdsc/web/controller/api/PostApiController.java
@@ -80,6 +80,13 @@ public class PostApiController {
         return ApiResponse.success("data", post);
     }
 
+    @ApiOperation(value = "카테고리 별 글 목록 불러오기", notes = "카테고리 별 모든 게시글을 조회합니다.")
+    @GetMapping("/api/v1/post/list/{categoryName}")
+    public ApiResponse findPostAllWithCategory(@PathVariable String categoryName, @PageableDefault
+            (size = 16, sort = "postId", direction = Sort.Direction.DESC) Pageable pageable){
+        Page<Post> post = postService.findPostAllWithCategory(categoryName, pageable);
+        return ApiResponse.success("data", post);
+    }
 
     @ApiOperation(value ="작성 게시글 불러오기", notes = "내가 작성한 게시글을 조회")
     @GetMapping("/api/member/v1/myPost")

--- a/src/main/java/Gdsc/web/repository/post/JpaPostRepository.java
+++ b/src/main/java/Gdsc/web/repository/post/JpaPostRepository.java
@@ -16,5 +16,6 @@ public interface JpaPostRepository extends JpaRepository<Post,Integer> {
     Optional<Post> findByPostIdAndMemberInfo(Long postId , MemberInfo memberInfo);
     Page<Post> findByMemberInfo(MemberInfo memberInfo, Pageable pageable);
     Page<Post> findByMemberInfoAndCategory(MemberInfo memberInfo, Optional<Category> category, Pageable pageable);
+    Page<Post> findByCategoryAndTmpStoreIsFalse(Optional<Category> category, Pageable pageable);
     Page<Post> findAllByTmpStoreIsFalse(Pageable pageable);
 }

--- a/src/main/java/Gdsc/web/service/PostService.java
+++ b/src/main/java/Gdsc/web/service/PostService.java
@@ -184,6 +184,13 @@ public class PostService {
                 ()-> new IllegalArgumentException("찾을 수 없는 카테고리 입니다.")));
         return jpaPostRepository.findByMemberInfoAndCategory(memberInfo, category, pageable);
     }
+    // 모든 게시글 카테고리 별 조회
+    @Transactional(readOnly = true)
+    public Page<Post> findPostAllWithCategory(String categoryName, final Pageable pageable){
+        Optional<Category> category = Optional.of(jpaCategoryRepository.findByCategoryName(categoryName).orElseThrow(
+                () -> new IllegalArgumentException("찾을 수 없는 카테고리 입니다.")));
+        return jpaPostRepository.findByCategoryAndTmpStoreIsFalse(category, pageable);
+    }
 
     //post 글 목록 불러오기
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 작업 내용 (Content)
- PostApiController 에 findPostAllWithCategory를 추가하였습니다
- 카테고리 이름을 GET 매핑 url로 받고 카테고리 별 모든 글을 조회하는 api 입니다
- /api/v1/post/list/{category} 

## 기타 사항 (Etc)
- 처음에 /api/v1/post/{category} 로 url 설정을 하려고 하였으나 중복 url 오류가 발생해서 /api/v1/post/list/{category} 로 바꾸었습니다.

## Merge 전 필요 작업 (Checklist before merge)
- [ ] 예) XX 테이블 추가, 앱 배포 등
- [ ] eg) Create XX table, Deploy app etc

## Merge 후 필요 작업 (Checklist after merge)
- PR이 생성되면 코드 리뷰 요청한 개발자에게 슬랙으로 알려주세요.