### PR TITLE
Feat AdminApitControllerTest 추가 및 권한 변경 Test코드 추가

### DIFF
--- a/src/main/java/Gdsc/web/controller/api/AdminApiController.java
+++ b/src/main/java/Gdsc/web/controller/api/AdminApiController.java
@@ -2,9 +2,11 @@ package Gdsc.web.controller.api;
 
 import Gdsc.web.dto.ApiResponse;
 import Gdsc.web.dto.WarningDto;
+import Gdsc.web.dto.requestDto.MemberRoleUpdateDto;
 import Gdsc.web.entity.Member;
 import Gdsc.web.entity.Post;
 import Gdsc.web.entity.WarnDescription;
+import Gdsc.web.model.RoleType;
 import Gdsc.web.service.AdminService;
 import Gdsc.web.service.PostBlockService;
 import Gdsc.web.service.PostService;
@@ -33,8 +35,10 @@ public class AdminApiController {
 
     @ApiOperation(value = "권한변경", notes = "권한 등급을 변경함.")
     @PutMapping("v1/update/role")
-    public ApiResponse<?> updateRole(@RequestBody Member member){
-        adminService.맴버권한수정(member);
+    public ApiResponse<?> updateRole(@RequestBody MemberRoleUpdateDto memberRoleUpdateDto){
+        String userId = memberRoleUpdateDto.getUserId();
+        RoleType role = memberRoleUpdateDto.getRole();
+        adminService.맴버권한수정(userId, role);
         return ApiResponse.success("message", "Success");
     }
 

--- a/src/main/java/Gdsc/web/dto/requestDto/MemberRoleUpdateDto.java
+++ b/src/main/java/Gdsc/web/dto/requestDto/MemberRoleUpdateDto.java
@@ -1,0 +1,10 @@
+package Gdsc.web.dto.requestDto;
+
+import Gdsc.web.model.RoleType;
+import lombok.Data;
+
+@Data
+public class MemberRoleUpdateDto {
+    private String userId;
+    private RoleType role;
+}

--- a/src/main/java/Gdsc/web/service/AdminService.java
+++ b/src/main/java/Gdsc/web/service/AdminService.java
@@ -22,13 +22,12 @@ public class AdminService {
     private final JpaMemberRepository repository;
     private final JpaWarnDescription jpaWarnDescription;
     @Transactional
-    public void 맴버권한수정(final Member member){
+    public void 맴버권한수정(String userId, RoleType role){
+        Member member = repository.findByUserId(userId);
         // Validations
         validate(member);
 
-        final Member original = repository.findByUserId(member.getUserId());
-        original.setRole(member.getRole());
-
+        member.setRole(role);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/Gdsc/web/controller/api/AdminApiControllerTest.java
+++ b/src/test/java/Gdsc/web/controller/api/AdminApiControllerTest.java
@@ -1,0 +1,80 @@
+package Gdsc.web.controller.api;
+
+import Gdsc.web.common.MemberEntityFactory;
+import Gdsc.web.dto.requestDto.MemberRoleUpdateDto;
+import Gdsc.web.entity.Member;
+import Gdsc.web.model.RoleType;
+import Gdsc.web.repository.member.JpaMemberRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import javax.transaction.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class AdminApiControllerTest {
+    @Autowired
+    private WebApplicationContext context;
+    private MockMvc mvc;
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    private JpaMemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        mvc = MockMvcBuilders.webAppContextSetup(context).addFilters(new CharacterEncodingFilter("UTF-8", true))  // 필터 추가
+                .alwaysDo(print())
+                .build();
+    }
+
+    @Test
+    @DisplayName("/api/admin/v1/update/role 권한 수정")
+    void updateRole() throws Exception {
+        // given
+        Member member = MemberEntityFactory.memberEntity();
+        memberRepository.save(member);
+        String url = "http://localhost:" + 8080 + "/api/admin/v1/update/role";
+        MemberRoleUpdateDto memberRoleUpdateDto = new MemberRoleUpdateDto();
+        memberRoleUpdateDto.setUserId(member.getUserId());
+        memberRoleUpdateDto.setRole(RoleType.CORE);
+        RoleType expected = RoleType.CORE;
+        // when
+        mvc.perform(put(url)
+                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+                        .content(mapper.writeValueAsString(memberRoleUpdateDto)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        // then
+        List<Member> memberList = memberRepository.findAll();
+        assertEquals(1, memberList.size());
+        assertEquals(expected, memberList.get(0).getRole());
+    }
+}


### PR DESCRIPTION
## 작업 내용 (Content)
- 테스트 코드를 작성하여 멤버 등급에서 코어 등급으로 바뀌는 것을 확인 하였습니다

## 기타 사항 (Etc)
admin컨트롤러 권한변경 api 에서 RequestBody로 Member Entity를 받던 것을 Dto를 생성해서 변경해주었습니다!

## Merge 전 필요 작업 (Checklist before merge)
- [ ] 예) XX 테이블 추가, 앱 배포 등
- [ ] eg) Create XX table, Deploy app etc

## Merge 후 필요 작업 (Checklist after merge)
- PR이 생성되면 코드 리뷰 요청한 개발자에게 슬랙으로 알려주세요.